### PR TITLE
FIX: iOS Bundle Display Name 변경

### DIFF
--- a/ios/eollugarn/Info.plist
+++ b/ios/eollugarn/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>eolluga-rn</string>
+	<string>얼루가게</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
직접 info.plist를 변경한거라 expo 빌드시 오류가 나거나 자체적으로 prebuild를 해서 적용이 안 될 수도 있습니다..!

그런 경우에는
<img width="692" alt="image" src="https://github.com/the-kingdoms/eollugage-rn/assets/117376841/c18e482e-3649-4c51-8e51-7021badb6fa7">

이렇게 변경하고 
`cd ios`
`pod update` or `pod install` 하고 build 한 번 더 해봐주세요! 

이렇게 했는데도 적용이 안된다면... xCode로 직접 빌드하는 방법도 있습니당